### PR TITLE
squashme: review pr 904

### DIFF
--- a/docs/libcurl/opts/Makefile.am
+++ b/docs/libcurl/opts/Makefile.am
@@ -458,6 +458,7 @@ HTMLPAGES =                                     \
  CURLOPT_IOCTLFUNCTION.html                     \
  CURLOPT_IPRESOLVE.html                         \
  CURLOPT_ISSUERCERT.html                        \
+ CURLOPT_KEEP_SENDING_ON_ERROR.html             \
  CURLOPT_KEYPASSWD.html                         \
  CURLOPT_KRBLEVEL.html                          \
  CURLOPT_LOCALPORT.html                         \
@@ -745,6 +746,7 @@ PDFPAGES =                                      \
  CURLOPT_IOCTLFUNCTION.pdf                      \
  CURLOPT_IPRESOLVE.pdf                          \
  CURLOPT_ISSUERCERT.pdf                         \
+ CURLOPT_KEEP_SENDING_ON_ERROR.pdf              \
  CURLOPT_KEYPASSWD.pdf                          \
  CURLOPT_KRBLEVEL.pdf                           \
  CURLOPT_LOCALPORT.pdf                          \

--- a/lib/url.c
+++ b/lib/url.c
@@ -784,7 +784,7 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
     break;
   case CURLOPT_KEEP_SENDING_ON_ERROR:
     data->set.http_keep_sending_on_error = (0 != va_arg(param, long)) ?
-        TRUE : FALSE;
+                                           TRUE : FALSE;
     break;
   case CURLOPT_UPLOAD:
   case CURLOPT_PUT:

--- a/packages/OS400/curl.inc.in
+++ b/packages/OS400/curl.inc.in
@@ -1254,6 +1254,8 @@
      d                 c                   10243
      d  CURLOPT_TCP_FASTOPEN...
      d                 c                   00244
+     d  CURLOPT_KEEP_SENDING_ON_ERROR...
+     d                 c                   00245
       *
       /if not defined(CURL_NO_OLDIES)
      d  CURLOPT_FILE   c                   10001

--- a/tests/libtest/lib1532.c
+++ b/tests/libtest/lib1532.c
@@ -49,9 +49,9 @@ static void reset_data(struct cb_data *data, CURL *curl)
 
 
 static size_t read_callback(void *ptr, size_t size, size_t nitems,
-    void *userdata)
+                            void *userdata)
 {
-  struct cb_data *data = (struct cb_data *) userdata;
+  struct cb_data *data = (struct cb_data *)userdata;
 
   /* wait until the server has sent all response headers */
   if(data->response_received) {
@@ -75,9 +75,9 @@ static size_t read_callback(void *ptr, size_t size, size_t nitems,
 
 
 static size_t write_callback(char *ptr, size_t size, size_t nmemb,
-    void *userdata)
+                             void *userdata)
 {
-  struct cb_data *data = (struct cb_data *) userdata;
+  struct cb_data *data = (struct cb_data *)userdata;
   size_t totalsize = nmemb * size;
 
   /* unused parameter */
@@ -97,7 +97,7 @@ static size_t write_callback(char *ptr, size_t size, size_t nmemb,
 
 
 static int perform_and_check_connections(CURL *curl, const char *description,
-    long expected_connections)
+                                         long expected_connections)
 {
   CURLcode res;
   long connections = 0;
@@ -115,7 +115,7 @@ static int perform_and_check_connections(CURL *curl, const char *description,
   }
 
   fprintf(stderr, "%s: expected: %ld connections; actual: %ld connections\n",
-    description, expected_connections, connections);
+          description, expected_connections, connections);
 
   if(connections != expected_connections) {
     return TEST_ERR_FAILURE;
@@ -147,7 +147,7 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_POST, 1L);
   test_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE,
-      (curl_off_t) data.remaining_bytes);
+              (curl_off_t)data.remaining_bytes);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
   test_setopt(curl, CURLOPT_READFUNCTION, read_callback);
   test_setopt(curl, CURLOPT_READDATA, &data);
@@ -155,7 +155,7 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_WRITEDATA, &data);
 
   res = perform_and_check_connections(curl,
-      "First request without CURLOPT_KEEP_SENDING_ON_ERROR", 1);
+    "First request without CURLOPT_KEEP_SENDING_ON_ERROR", 1);
   if(res != TEST_ERR_SUCCESS) {
     goto test_cleanup;
   }
@@ -163,7 +163,7 @@ int test(char *URL)
   reset_data(&data, curl);
 
   res = perform_and_check_connections(curl,
-      "Second request without CURLOPT_KEEP_SENDING_ON_ERROR", 1);
+    "Second request without CURLOPT_KEEP_SENDING_ON_ERROR", 1);
   if(res != TEST_ERR_SUCCESS) {
     goto test_cleanup;
   }
@@ -173,7 +173,7 @@ int test(char *URL)
   reset_data(&data, curl);
 
   res = perform_and_check_connections(curl,
-      "First request with CURLOPT_KEEP_SENDING_ON_ERROR", 1);
+    "First request with CURLOPT_KEEP_SENDING_ON_ERROR", 1);
   if(res != TEST_ERR_SUCCESS) {
     goto test_cleanup;
   }
@@ -181,7 +181,7 @@ int test(char *URL)
   reset_data(&data, curl);
 
   res = perform_and_check_connections(curl,
-      "Second request with CURLOPT_KEEP_SENDING_ON_ERROR", 0);
+    "Second request with CURLOPT_KEEP_SENDING_ON_ERROR", 0);
   if(res != TEST_ERR_SUCCESS) {
     goto test_cleanup;
   }


### PR DESCRIPTION
minor alignment issues, refer to https://github.com/curl/curl/blob/master/docs/CODE_STYLE.md#column-alignment

could also be

``` c
  res = perform_and_check_connections(curl, "First request without "
                                      "CURLOPT_KEEP_SENDING_ON_ERROR", 1);
```

however I agree the other way is easier, so in that case 2 space indent
